### PR TITLE
Feature/makePolyline

### DIFF
--- a/src/components/map/kakak-map.tsx
+++ b/src/components/map/kakak-map.tsx
@@ -5,10 +5,11 @@ interface props {
   size: number[];
 }
 
+// 넘어오는 markerPositions
 export default function KakaoMap({ markerPositions, size }: props) {
-  // const { markerPositions, size } = props;
   const [kakaoMap, setKakaoMap] = useState<kakao.maps.Map>();
   const [, setMarkers] = useState<kakao.maps.Marker[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const container = useRef<HTMLDivElement>(null);
 
@@ -30,11 +31,12 @@ export default function KakaoMap({ markerPositions, size }: props) {
         //setMapCenter(center);
         setKakaoMap(map);
       });
+      setIsLoading(false);
     };
   }, [container]);
 
   useEffect(() => {
-    if (kakaoMap === null) {
+    if (kakaoMap === null || isLoading) {
       return;
     }
 
@@ -57,20 +59,14 @@ export default function KakaoMap({ markerPositions, size }: props) {
   }, [kakaoMap, size]);
 
   useEffect(() => {
-    if (kakaoMap === null) {
+    if (kakaoMap === undefined || isLoading) {
       return;
     }
 
     const positions = markerPositions.map((pos) => {
       const [latitude, longitude] = [pos[0], pos[1]];
-      // console.log(latitude, longitude);
       return new kakao.maps.LatLng(latitude, longitude);
     });
-
-    // const positions = markerPositions.map((pos) => {
-    //   console.log(...pos);
-    //   return new kakao.maps.LatLng(...pos);
-    // });
 
     setMarkers((markers) => {
       // clear prev markers
@@ -92,6 +88,18 @@ export default function KakaoMap({ markerPositions, size }: props) {
       if (kakaoMap === undefined) return;
       kakaoMap.setBounds(bounds);
     }
+
+    // 지도에 표시할 선을 생성합니다
+    const polyline = new kakao.maps.Polyline({
+      path: positions, // 선을 구성하는 좌표배열 입니다
+      strokeWeight: 5, // 선의 두께 입니다
+      strokeColor: "#FFAE00", // 선의 색깔입니다
+      strokeOpacity: 0.7, // 선의 불투명도 입니다 1에서 0 사이의 값이며 0에 가까울수록 투명합니다
+      strokeStyle: "solid", // 선의 스타일입니다
+    });
+
+    // 지도에 선을 표시합니다
+    polyline.setMap(kakaoMap);
   }, [kakaoMap, markerPositions]);
 
   return <div id='container' ref={container} />;

--- a/src/pages/maptest/index.tsx
+++ b/src/pages/maptest/index.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import KakaoMap from "../../components/map/kakak-map";
+
+export default function Maptest() {
+  // const [visible, setVisible] = useState(true);
+  const [mapSize, setMapSize] = useState([400, 400]);
+  const [markerPositions, setMarkerPositions] = useState<number[][]>([]);
+
+  const markerPositions1 = [
+    [33.452278, 126.567803],
+    [33.452671, 126.574792],
+    [33.451744, 126.572441],
+  ];
+  const markerPositions2 = [
+    [37.499590490909185, 127.0263723554437],
+    [37.499427948430814, 127.02794423197847],
+    [37.498553760499505, 127.02882598822454],
+    [37.497625593121384, 127.02935713582038],
+    [37.49629291770947, 127.02587362608637],
+    [37.49754540521486, 127.02546694890695],
+    [37.49646391248451, 127.02675574250912],
+  ];
+
+  return (
+    <>
+      <button onClick={() => setMarkerPositions(markerPositions1)}>
+        Marker Set 1
+      </button>
+      <button onClick={() => setMarkerPositions(markerPositions2)}>
+        Marker Set 2
+      </button>
+      <h2>Kakao Map</h2>
+      <KakaoMap markerPositions={markerPositions1} size={mapSize} />
+    </>
+  );
+}


### PR DESCRIPTION
<!-- PR제목은 변경하지 않습니다 -->
<!-- 브랜치명을 이슈라벨/작업내용으로 맞춰서 작성하고, PR제목에 그대로 사용합니다 -->
## 이슈번호
 #18 
#12
## 1. 작업내용
- 지도에 마커를 표시할 때 마커의 좌표를 props로 받아옵니다. 이전에는 상수로 받아왔었습니다.
- 받아온 좌표들의 위/경도 값을 기준으로 폴리라인을 생성합니다.
![image](https://user-images.githubusercontent.com/12118892/220529794-b1c77470-20d6-451f-a636-0afa70489547.png)

## 2. 작업 하면서 겪은 이슈
- script가 완전히 로드되기전에 'kakao' 객체를 사용하게끔 되어있어서 'kakao is not defined' 에러가 있었습니다. useState를 사용하여 isLoading 상태를 만들어 줌으로써 script가 모두 로드되고나서 이후의 코드들이 실행되게하여 문제를 해결했습니다.
## 3. PR 포인트
- 현재 더미 데이터는 API 명세서에 있는 response 모습과 다릅니다. 추후에 더미데이터를 response의 모습과 동일하게 만들어서 다시 테스트한 후 API 통신과 연동하도록 하겠습니다.
