### PR TITLE
Fix/mid point duplicate start point

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,7 +33,7 @@ const {
 
 const { LOGIN_TEXT, CLOSE_TEXT, MAKE_A_GROUP_TEXT } = MODAL_TEXT;
 
-const { ERROR_UNSELECT_PEOPLE_COUNT } = ERROR_TEXT;
+const { ERROR_UNSELECT_PEOPLE_COUNT, ERROR_DUPLICATE_START_POINT } = ERROR_TEXT;
 
 const { SEARCH, LOGIN, MAP, GROUP, HOME } = ROUTES;
 
@@ -196,6 +196,8 @@ export default function Home() {
       if (errorMessage) throw new Error(errorMessage);
 
       const data = await MidPointApi.postMidPoint(notEmptyAddressList);
+
+      if (data.start.length <= 1) throw new Error(ERROR_DUPLICATE_START_POINT);
 
       setAddressList(notEmptyAddressList);
       setMidPointResponse(data);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -10,18 +10,15 @@ export const validateAddressListUnderTwoLength = (
     return ERROR_MISSING_START_POINT;
   }
 
-  if (addressList.length === 2) {
-    const one = addressList[0];
-    const two = addressList[1];
+  let prevAddress = addressList[0];
+  for (const curAddress of addressList) {
+    const { stationName: pStation, lat: pLat, lng: pLng } = prevAddress;
+    const { stationName: cStation, lat: cLat, lng: cLng } = curAddress;
 
-    if (
-      one.stationName === two.stationName &&
-      one.lat === two.lat &&
-      one.lng === two.lng
-    ) {
-      return ERROR_DUPLICATE_START_POINT;
-    }
+    if (pStation !== cStation || pLat !== cLat || pLng !== cLng) return "";
+
+    prevAddress = curAddress;
   }
 
-  return "";
+  return ERROR_DUPLICATE_START_POINT;
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -12,10 +12,10 @@ export const validateAddressListUnderTwoLength = (
 
   let prevAddress = addressList[0];
   for (const curAddress of addressList) {
-    const { stationName: pStation, lat: pLat, lng: pLng } = prevAddress;
-    const { stationName: cStation, lat: cLat, lng: cLng } = curAddress;
+    const { lat: pLat, lng: pLng } = prevAddress;
+    const { lat: cLat, lng: cLng } = curAddress;
 
-    if (pStation !== cStation || pLat !== cLat || pLng !== cLng) return "";
+    if (pLat !== cLat || pLng !== cLng) return "";
 
     prevAddress = curAddress;
   }


### PR DESCRIPTION
<!-- PR제목은 변경하지 않습니다 -->
<!-- 브랜치명을 이슈라벨/작업내용으로 맞춰서 작성하고, PR제목에 그대로 사용합니다 -->

## 이슈번호

## 1. 작업내용

- 기존 2개의 출발지에만 중복 출발지 체크가 유효했던 것을 확인하게 되었습니다.
  인자 개수에 상관없이 중복 체크하도록 코드를 수정해서 올립니다.

예외처리 상황
1. 좌표가 같으면 중복 출발지로 인식합니다.
2. 같은 역 다른 노선에 대해서는 백엔드 응답 데이터를 통해서 중복 출발지를 판단합니다
    - 만약 배열 요소가 1개만 있다면 중복 출발지로 판단하고 예외처리합니다.

## 2. 작업 하면서 겪은 이슈

-

## 3. PR 포인트

-
