### PR TITLE
fix: 검색화면 모달에서 '아니오' 클릭시 메인화면으로 이동하도록 수정.

### DIFF
--- a/src/components/search/search-input.tsx
+++ b/src/components/search/search-input.tsx
@@ -37,9 +37,11 @@ const SearchInput = () => {
         confirm: "예",
         close: "아니오",
       },
-      // 출발지 확정시
       handleConfirm: () => {
         // router.push("/");
+      },
+      handleClose: () => {
+        router.push("/");
       },
     });
   }, [openModal]);

--- a/src/components/search/search-input.tsx
+++ b/src/components/search/search-input.tsx
@@ -44,7 +44,7 @@ const SearchInput = () => {
         router.push("/");
       },
     });
-  }, [openModal]);
+  }, [openModal, router]);
 
   // URL Params에 groupId가 포함되어 있으면 모달을 보여준다.
   useEffect(() => {


### PR DESCRIPTION
<!-- PR제목은 변경하지 않습니다 -->
<!-- 브랜치명을 이슈라벨/작업내용으로 맞춰서 작성하고, PR제목에 그대로 사용합니다 -->

## 이슈번호

## 1. 작업내용

- 초대 링크로 접속시 '아니오'를 클릭해도 검색화면에 남아있던 문제를 수정했습니다.

## 2. 작업 하면서 겪은 이슈

- 無

## 3. PR 포인트

- 이제 초대 링크로 접속시 '아니오'를 클릭하면 '홈 화면' 으로 이동합니다.
