### PR TITLE
Bugfix/hydration error

### DIFF
--- a/src/components/map/places-button.tsx
+++ b/src/components/map/places-button.tsx
@@ -3,18 +3,22 @@ import { SHADOWS } from "@/constants/css";
 import styled from "@emotion/styled";
 import { Menu } from "@mui/icons-material";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 interface PlacesButtonProps {
   stationName: string;
 }
 
 const PlacesButton = ({ stationName }: PlacesButtonProps) => {
+  const [href, setHref] = useState("");
+
+  useEffect(() => {
+    const href = `/place?stationName=${stationName}`;
+    setHref(href);
+  }, [stationName]);
+
   return (
-    <StyledLink
-      href={{
-        pathname: "/place",
-        query: { stationName },
-      }}>
+    <StyledLink href={href}>
       <Menu sx={{ color: COLORS.mainGreen, fontSize: "2rem" }} />
       <span>주변 장소 목록</span>
     </StyledLink>

--- a/src/hooks/use-map.ts
+++ b/src/hooks/use-map.ts
@@ -21,7 +21,7 @@ const useMap = ({
 
   useEffect(() => {
     const script = document.createElement("script");
-    script.async = true;
+    script.defer = true;
     script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_MAP_KEY}&autoload=false`;
     setScript(script);
     document.head.appendChild(script);

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,15 @@
 import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
-    <Html lang='en'>
+    <Html lang='ko'>
       <Head>
         <meta
           http-equiv='Content-Security-Policy'
           content='upgrade-insecure-requests'
         />
         <meta name='referrer' content='no-referrer' />
+        <link rel='preconnect' href='https://dapi.kakao.com' />
+        <link rel='dns-prefetch' href='https://dapi.kakao.com' />
       </Head>
       <body>
         <Main />

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -1,17 +1,19 @@
 import MidpointButton from "@/components/map/midpoint-button";
 import styled from "@emotion/styled";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useMap from "@/hooks/use-map";
 import { useRecoilValue } from "recoil";
 import { MidPointState } from "@/recoil/midpoint-state";
 import PlacesButton from "@/components/map/places-button";
 import MapHeader from "@/components/map/map-header";
 import { Stack } from "@mui/material";
+import { EndpointResponse } from "@/types/api/midpoint";
 
 const MapPage = () => {
   const [currentMidway, setCurrentMidway] = useState(0);
   const mapContainerRef = useRef(null);
   const { start, midPointResponses } = useRecoilValue(MidPointState);
+  const [midpoints, setMidpoints] = useState<EndpointResponse[]>();
   const { map, setMidpoint } = useMap({
     mapContainerRef,
     initialCenter: {
@@ -31,21 +33,26 @@ const MapPage = () => {
     setCurrentMidway(midPointResponses.indexOf(midpoint));
   };
 
+  useEffect(() => {
+    setMidpoints(midPointResponses);
+  }, [midPointResponses]);
+
   return (
     <Wrapper>
       <Container>
         <MapHeader />
         <Stack direction='row' spacing={4} justifyContent='center'>
-          {midPointResponses.map((data, index) => (
-            <MidpointButton
-              key={data.id}
-              id={data.id}
-              stationName={data.stationName}
-              isCurrent={currentMidway === index}
-              onClick={handleNavigate}
-              line={data.line}
-            />
-          ))}
+          {midpoints &&
+            midpoints.map((data, index) => (
+              <MidpointButton
+                key={data.id}
+                id={data.id}
+                stationName={data.stationName}
+                isCurrent={currentMidway === index}
+                onClick={handleNavigate}
+                line={data.line}
+              />
+            ))}
         </Stack>
       </Container>
       <Map ref={mapContainerRef} id='mapContainerRef' />


### PR DESCRIPTION
<!-- PR제목은 변경하지 않습니다 -->
<!-- 브랜치명을 이슈라벨/작업내용으로 맞춰서 작성하고, PR제목에 그대로 사용합니다 -->

## 이슈번호
closes #79 
## 1. 작업내용
<img width="397" alt="KakaoTalk_Photo_2023-03-14-00-29-36" src="https://user-images.githubusercontent.com/25377159/224749079-04a66d41-9cb2-4a8e-80ed-d7682d37aed4.png">

-  `<MidpointButton/>`을 그리기 위한 `midPointResponses`가 로컬스토리지에서 가져오다 보니 서버에서 pre-render한 HTML과 클라이언트에서 hydration하는 HTML과 일치하지 않다는 에러가 있었습니다.  
     - 따라서 `useEffect`를 이용해 페이지가 마운트 된 뒤 `midPointResponses`를 사용할 수 있도록 새로운 상태값으로 저장하는 방법으로 처리했습니다.

<img width="625" alt="KakaoTalk_Photo_2023-03-14-00-29-46" src="https://user-images.githubusercontent.com/25377159/224751511-2b8ec0be-3660-4086-b4e2-18e7ba606e74.png">

-  위와 비슷한 이유로 `<PlacesButton/>`에서 아직 서버에선 `stationName`이 undefined로 되어있어 useEffect로 컴포넌트 마운투 뒤 href를 만들어주는 방법으로 처리했습니다.
- 지도 API 오리진 pre-connect 및 dns-prefetch 설정

## 2. 작업 하면서 겪은 이슈

-

## 3. PR 포인트

- 에러들은 처리했지만.. 이렇게 처리하는게 맞는지 확신하지 않습니다 ㅠ 다른 방법있으시다면 말씀해주세요
